### PR TITLE
[BUG] prevent box malforming when breath or width is 0

### DIFF
--- a/libs/vector.py
+++ b/libs/vector.py
@@ -1,0 +1,19 @@
+import math
+
+class Vector():
+    def __init__(self, qpoint1, qpoint2):
+        self.x = qpoint2.x() - qpoint1.x()
+        self.y = qpoint2.y() - qpoint1.y()
+
+    def dot_product(self, vector):
+        return self.x * vector.x + self.y * vector.y
+    
+    def magnitude(self):
+        return math.sqrt(self.x**2 + self.y**2)
+
+    def projection(self, vector):
+        dot = self.dot_product(vector)
+        magnitude = vector.magnitude()
+
+        return dot / (magnitude**2)
+        


### PR DESCRIPTION
Previously when box width or height is 0, there is a zero division error when u try to edit its dimension.

This PR will prevent the width or height being set to 0. Also added a vector class for more convenient calculations